### PR TITLE
Fix to accomodate for ts column

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # IBM Db2 Event Store Streaming Connector for Kafka
 
+The IBM Db2 Event Store is an in-memory database optimized for event-driven data processing and analysis. [Download the free developer edition or the enterprise edition](https://www.ibm.com/us-en/marketplace/db2-event-store)
+
+In order to run our Open Source Apache Kafka Connector, follow the steps below:
+
 ## Pre-requisites
 ```
 Install sbt at the version 0.13.16

--- a/event-stream/src/main/scala/org/event/store/stream/Event.scala
+++ b/event-stream/src/main/scala/org/event/store/stream/Event.scala
@@ -3,11 +3,11 @@ package org.event.store.stream
 class Event () {
   var id: Long = 0L
   var metadataId: Long = 0L
-  var timestamp: Long = 0L
+  var ts: Long = 0L
   var value: Long = 0L
 
   def setId (id: Long): Unit = {this.id = id}
   def setMetadataId (metadataId: Long): Unit =  {this.metadataId = metadataId}
-  def setTimestamp (timestamp: Long): Unit =  {this.timestamp = timestamp}
+  def setTimestamp (ts: Long): Unit =  {this.ts = ts}
   def setValue (value: Long): Unit =  {this.value = value}
 }

--- a/event-stream/src/main/scala/org/event/store/stream/EventStoreConnector.scala
+++ b/event-stream/src/main/scala/org/event/store/stream/EventStoreConnector.scala
@@ -66,12 +66,12 @@ class EventStoreConnector(createContext: () => Option[EventContext], settings: E
         val tableDefinition = TableSchema(tableName, StructType(Array(
           StructField("id", LongType, nullable = false),
           StructField(s"${settings.getMetadata()}", LongType, nullable = false),
-          StructField("timestamp", LongType, nullable = false),
+          StructField("ts", LongType, nullable = false),
           StructField("value", LongType, nullable = false)
         )),
-          shardingColumns = Seq("timestamp", s"${settings.getMetadata()}"),
-          pkColumns = Seq("timestamp", s"${settings.getMetadata()}"))
-        val indexDefinition = IndexSpecification("IndexDefinition", tableDefinition, equalColumns = Seq(s"${settings.getMetadata()}"), sortColumns = Seq(SortSpecification("timestamp", ColumnOrder.AscendingNullsLast)), includeColumns = Seq("value"))
+          shardingColumns = Seq("ts", s"${settings.getMetadata()}"),
+          pkColumns = Seq("ts", s"${settings.getMetadata()}"))
+        val indexDefinition = IndexSpecification("IndexDefinition", tableDefinition, equalColumns = Seq(s"${settings.getMetadata()}"), sortColumns = Seq(SortSpecification("ts", ColumnOrder.AscendingNullsLast)), includeColumns = Seq("value"))
         val status = ctx.get.createTableWithIndex(tableDefinition, indexDefinition)
         if (!status.isDefined) {
           this.table = Some(ctx.get.getTable(tableName))
@@ -84,7 +84,7 @@ class EventStoreConnector(createContext: () => Option[EventContext], settings: E
   }
 
   private def generateRow(event: Event): Row = {
-    Row.fromSeq(Seq(event.id, event.metadataId, event.timestamp, event.value))
+    Row.fromSeq(Seq(event.id, event.metadataId, event.ts, event.value))
   }
 
   def parseJSON (message: String): Event = {
@@ -99,7 +99,7 @@ class EventStoreConnector(createContext: () => Option[EventContext], settings: E
         if (!this.tableName.isDefined && "table".equals(fieldName)) {this.tableName = Some(parser.getValueAsString)}
         else if ("id".equals(fieldName)) {event.id = parser.getValueAsLong}
         else if (s"${settings.getMetadata()}".equals(fieldName)) {event.metadataId = parser.getValueAsLong}
-        else if ("timestamp".equals(fieldName)) {event.timestamp = parser.getValueAsLong}
+        else if ("ts".equals(fieldName)) {event.ts = parser.getValueAsLong}
         else if ("value".equals(fieldName)) {event.value = parser.getValueAsLong}
       }
     }


### PR DESCRIPTION
Fix to rename the column from timestamp to ts, since the grafana sample code relies on ts currently.